### PR TITLE
Updating date parsing to fix moment deprecation error

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -8,6 +8,8 @@ var argv = require('yargs')
   .alias('g', 'group-name')
   .alias('s', 'stream-name')
   .alias('h', 'help')
+  .alias('f', 'format')
+  .default('format', 'YYYY-MM-DD')
   .default('streams', false)
   .default('limit', 100)
   .argv;

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -98,12 +98,14 @@ var getLogs = function(cwlogs, groupName, argv, nextToken, runningCount) {
     params.limit = limit;
   }
 
+  var dateFormat = argv.format;
+
   if(argv.since) {
-    params.startTime = moment(argv.since).valueOf();
+    params.startTime = moment(argv.since, dateFormat).valueOf();
   }
 
   if(argv.until) {
-    params.endTime = moment(argv.until).valueOf();
+    params.endTime = moment(argv.until, dateFormat).valueOf();
   }
 
   if(argv.filterStatus) {

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -101,11 +101,22 @@ var getLogs = function(cwlogs, groupName, argv, nextToken, runningCount) {
   var dateFormat = argv.format;
 
   if(argv.since) {
-    params.startTime = moment(argv.since, dateFormat).valueOf();
+    var sinceTime = moment(argv.since, dateFormat).valueOf();
+    if(sinceTime > 0) {
+      params.startTime = sinceTime;
+    } else {
+      console.log('WARNING: Error parsing --since "' + argv.since + '" against format ' + dateFormat);
+    }
+
   }
 
   if(argv.until) {
-    params.endTime = moment(argv.until, dateFormat).valueOf();
+    var endTime = moment(argv.until, dateFormat).valueOf();
+    if(endTime > 0) {
+      params.endTime = end;
+    } else {
+      console.log('WARNING: Error parsing --until "' + argv.until + '" against format ' + dateFormat);
+    }
   }
 
   if(argv.filterStatus) {


### PR DESCRIPTION
Fixes #4 

Note: This is one way to handle this deprecation error according to: https://github.com/moment/moment/issues/1407

The fix is to enforce a format when sending a date in currently defaulting to `YYYY-MM-DD`. 

Another option is to utilize `Date()` to handle parsing the string and sending that to the moment lib.
